### PR TITLE
fix: Support redis 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,16 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      max-parallel: 4
+      matrix:
+        redis-py: [3.*, 4.*]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
 
-      - run: make develop test
+      - run: make develop
+      - run: pip install redis==${{ matrix.redis-py }}
+      - run: make test

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url="https://github.com/getsentry/sentry-redis-tools",
     description="Common utilities related to how Sentry uses Redis",
     zip_safe=False,
-    install_requires=['redis>=4.0'],
+    install_requires=['redis>=3.0'],
     packages=find_packages(exclude=("tests", "tests.*")),
     package_data={"sentry_redis_tools": ["py.typed"]},
     include_package_data=True,


### PR DESCRIPTION
It turns out we use redis v3 in Sentry, so we need to be able to use
FailoverRedis with that version.

We should investigate (again) what it takes to upgrade redis though.
