### PR TITLE
feat: Add retrying redis cluster

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,3 @@ ignore_missing_imports = True
 
 [mypy-rb.*]
 ignore_missing_imports = True
-
-[mypy-tests.*]
-ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,6 @@ ignore_missing_imports = True
 
 [mypy-rb.*]
 ignore_missing_imports = True
+
+[mypy-tests.*]
+ignore_missing_imports = True

--- a/sentry_redis_tools/retrying_cluster.py
+++ b/sentry_redis_tools/retrying_cluster.py
@@ -1,0 +1,44 @@
+from typing import Any
+from sentry_redis_tools.clients import RedisCluster
+
+from redis.exceptions import BusyLoadingError, ConnectionError
+
+try:
+    from redis.exceptions import ClusterError
+except ImportError:
+    from rediscluster.exceptions import ClusterError
+
+__all__ = ["ClusterError", "RetryingRedisCluster"]
+
+
+class RetryingRedisCluster(RedisCluster):  # type: ignore
+    """
+    Execute a command with cluster reinitialization retry logic.
+
+    Should a cluster respond with a ConnectionError or BusyLoadingError the
+    cluster nodes list will be reinitialized and the command will be executed
+    again with the most up to date view of the world.
+    """
+
+    def execute_command(self, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return super(self.__class__, self).execute_command(*args, **kwargs)
+        except (
+            ConnectionError,
+            BusyLoadingError,
+            ClusterError,
+            KeyError,  # see: https://github.com/Grokzen/redis-py-cluster/issues/287
+        ):
+            # Codepath for redis-py-cluster
+            if hasattr(self, "connection_pool"):
+                self.connection_pool.nodes.reset()
+
+            # Codepath for redis.cluster
+            #
+            # the code in the RedisCluster __init__ idiotically sets
+            # self.nodes_manager = None
+            # self.nodes_manager = NodesManager(...)
+            if hasattr(self, "nodes_manager"):
+                self.nodes_manager.reset()
+
+            return super(self.__class__, self).execute_command(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,19 @@
-from typing import Union
+from typing import Union, Type
 
 import pytest
 import redis
 
 from sentry_redis_tools.clients import StrictRedis, BlasterClient, RedisCluster
+
+
+def initialize_redis_cluster(cls: Type[RedisCluster] = RedisCluster) -> RedisCluster:
+    if redis.VERSION >= (4,):
+        client = cls.from_url("redis://127.0.0.1:16379")
+    else:
+        client = cls(startup_nodes=[{"host": "127.0.0.1", "port": "16379"}])
+
+    client.flushdb()
+    return client
 
 
 def _build_client(param: str) -> Union[StrictRedis, RedisCluster, BlasterClient]:
@@ -17,15 +27,7 @@ def _build_client(param: str) -> Union[StrictRedis, RedisCluster, BlasterClient]
         return client
 
     elif param == "cluster":
-        if redis.VERSION >= (4,):
-            client = RedisCluster.from_url("redis://127.0.0.1:16379")
-        else:
-            client = RedisCluster(
-                startup_nodes=[{"host": "127.0.0.1", "port": "16379"}]
-            )
-
-        client.flushdb()
-        return client
+        return initialize_redis_cluster()
     else:
         raise ValueError(param)
 

--- a/tests/test_retrying_cluster.py
+++ b/tests/test_retrying_cluster.py
@@ -1,0 +1,45 @@
+import pytest
+
+from typing import Type
+from unittest import mock
+
+from redis.exceptions import BusyLoadingError, ConnectionError
+from sentry_redis_tools.retrying_cluster import ClusterError, RetryingRedisCluster
+
+from tests.conftest import initialize_redis_cluster
+
+
+@pytest.mark.parametrize(
+    "exception_cls",
+    [
+        ConnectionError,
+        BusyLoadingError,
+        ClusterError,
+        KeyError,
+    ],
+)
+@mock.patch("sentry_redis_tools.clients.RedisCluster.execute_command")
+def test_basic(execute_command: mock.Mock, exception_cls: Type[Exception]) -> None:
+    client = initialize_redis_cluster(cls=RetryingRedisCluster)
+
+    execute_command.side_effect = exception_cls()
+    execute_command.reset_mock()
+
+    with pytest.raises(exception_cls):
+        client.get("key")
+
+    assert execute_command.call_args_list == [
+        mock.call("GET", "key"),
+        mock.call("GET", "key"),
+    ]
+
+    execute_command.side_effect = [exception_cls(), None]
+
+    assert client.get("key") is None
+
+    assert execute_command.call_args_list == [
+        mock.call("GET", "key"),
+        mock.call("GET", "key"),
+        mock.call("GET", "key"),
+        mock.call("GET", "key"),
+    ]


### PR DESCRIPTION
Copied from sources:

https://github.com/getsentry/sentry/blob/14b3872fa829d6dd5e31904dd10b8c4880d335ef/src/sentry/utils/redis.py#L76-L86
https://github.com/getsentry/snuba/blob/45f54a420efd4ee63b527e8c24f4cbf3356a1110/snuba/redis.py#L37-L48

It turns out that the implementations in sentry and snuba have drifted
apart. Aside from the elephant in the room where sentry is running on
redis-py-cluster, and snuba on redis.cluster, the sentry version has
been changed to also catch ClusterError while the snuba version doesn't.

Other than that there's no differences at all.

Fix https://getsentry.atlassian.net/browse/SNS-1315
