### PR TITLE
Remove `redis-py-cluster` dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: |
           pip install wheel
           python setup.py sdist bdist_wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
 
       - run: make develop
       - run: make lint
@@ -29,15 +27,14 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        redis-py: [3.*, 4.*]
+        redis-py: [4.*]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
 
+      - name: Install redis-cli
+        run: sudo apt-get install redis-tools
       - run: make develop
-      - run: pip install -U docker-compose
       - run: make redis-cluster
       - run: pip install redis==${{ matrix.redis-py }}
       - run: make test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,9 @@ jobs:
     name: Sphinx
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
+        uses: actions/setup-python@v5
 
       - name: Build docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Release a new version"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /dist
 /build
 /docs/_build/
+.idea

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew 'redis'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 black==22.6.0
 flake8==5.0.4
-mypy==0.971
+mypy==1.8
 pytest>=7.2.0
 sphinx-autodoc-typehints[type-comment]>=1.19.3
 sphinx-rtd-theme
-rb>=1.9.0
-redis-py-cluster>=2.1.0
+rb>=1.10.0

--- a/sentry_redis_tools/clients.py
+++ b/sentry_redis_tools/clients.py
@@ -1,9 +1,5 @@
 from typing import NoReturn
-
-try:
-    from redis import RedisCluster
-except ImportError:
-    from rediscluster import RedisCluster
+from redis import RedisCluster
 
 try:
     from rb import Cluster as BlasterClient

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import find_packages, setup
 
-from typing import Sequence
-
-
 setup(
     name="sentry-redis-tools",
     version="0.1.7",
@@ -12,7 +9,7 @@ setup(
     url="https://github.com/getsentry/sentry-redis-tools",
     description="Common utilities related to how Sentry uses Redis",
     zip_safe=False,
-    install_requires=['redis>=3.0'],
+    install_requires=['redis>=4.1.0'],
     packages=find_packages(exclude=("tests", "tests.*")),
     package_data={"sentry_redis_tools": ["py.typed"]},
     include_package_data=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,14 @@
 from typing import Union, Type
 
 import pytest
-import redis
 
 from sentry_redis_tools.clients import StrictRedis, BlasterClient, RedisCluster
 
 
 def initialize_redis_cluster(cls: Type[RedisCluster] = RedisCluster) -> RedisCluster:
-    if redis.VERSION >= (4,):
-        client = cls.from_url("redis://127.0.0.1:16379")
-    else:
-        client = cls(startup_nodes=[{"host": "127.0.0.1", "port": "16379"}])
-
+    client = cls.from_url("redis://127.0.0.1:16379")  # type: ignore
     client.flushdb()
-    return client
+    return client  # type: ignore
 
 
 def _build_client(param: str) -> Union[StrictRedis, RedisCluster, BlasterClient]:

--- a/tests/test_cardinality_limiter.py
+++ b/tests/test_cardinality_limiter.py
@@ -57,7 +57,9 @@ def test_basic(limiter: RedisCardinalityLimiter) -> None:
     for _ in range(20):
         assert helper.add_value(2) == 2
 
-    assert [helper.add_value(10 + i) for i in range(100)] == list(range(10, 18)) + [None] * 92  # type: ignore
+    assert [helper.add_value(10 + i) for i in range(100)] == list(range(10, 18)) + [
+        None
+    ] * 92
 
     helper.timestamp += 3600
 
@@ -67,7 +69,9 @@ def test_basic(limiter: RedisCardinalityLimiter) -> None:
     # `cardinality:timeseries` keys for 1, 2 still exist in this test setup
     # (and we would admit them on top of 10..20), but they won't in a
     # real-world scenario
-    assert [helper.add_value(10 + i) for i in range(100)] == list(range(10, 20)) + [None] * 90  # type: ignore
+    assert [helper.add_value(10 + i) for i in range(100)] == list(range(10, 20)) + [
+        None
+    ] * 90
 
 
 def test_multiple_prefixes(limiter: RedisCardinalityLimiter) -> None:
@@ -226,7 +230,7 @@ def test_sampling_going_bad(limiter: RedisCardinalityLimiter) -> None:
     # when adding "hashes" 0..10 in ascending order, the first hash will fill
     # up the physical shard, and a total count of 10 is extrapolated from that
     admissions = [helper.add_value(i) for i in range(10)]
-    assert admissions == [0] + [None] * 9  # type: ignore
+    assert admissions == [0] + [None] * 9
 
 
 def test_regression_mixed_order(limiter: RedisCardinalityLimiter) -> None:

--- a/tests/test_failover_redis.py
+++ b/tests/test_failover_redis.py
@@ -64,5 +64,5 @@ def test_pipelines(time_sleep: mock.Mock, execute_command: mock.Mock) -> None:
     with pytest.raises(ConnectionError):
         pipe = client.pipeline()
         pipe.get("key")
-        pipe.execute()
+        pipe.execute()  # type: ignore
     assert all(a[0][0] <= 1.0 for a in time_sleep.call_args_list)

--- a/tests/test_retrying_cluster.py
+++ b/tests/test_retrying_cluster.py
@@ -6,8 +6,6 @@ from unittest import mock
 from redis.exceptions import BusyLoadingError, ConnectionError
 from sentry_redis_tools.retrying_cluster import ClusterError, RetryingRedisCluster
 
-from tests.conftest import initialize_redis_cluster
-
 
 @pytest.mark.parametrize(
     "exception_cls",
@@ -20,7 +18,8 @@ from tests.conftest import initialize_redis_cluster
 )
 @mock.patch("sentry_redis_tools.clients.RedisCluster.execute_command")
 def test_basic(execute_command: mock.Mock, exception_cls: Type[Exception]) -> None:
-    client = initialize_redis_cluster(cls=RetryingRedisCluster)
+    client = RetryingRedisCluster.from_url("redis://127.0.0.1:16379")  # type: ignore
+    client.flushdb()
 
     execute_command.side_effect = exception_cls()
     execute_command.reset_mock()


### PR DESCRIPTION
- removes `redis-py-cluster` dependency
- removes redis v3 support since it doesn't support RedisCluster
- updates GitHub workflows
- updates Mypy and rb