### PR TITLE
feat: remove `rediscluster`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/setup-python@v5
 
       - run: make develop
+      - run: pip install redis==4.*
       - run: make lint
       - run: make format
       - run: git diff --quiet || (echo '::error ::lint produced file changes, run linter locally and try again' && exit 1)
@@ -27,7 +28,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        redis-py: [3.*, 4.*]
+        redis-py: [4.*]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 develop:
-	pip install -e .[cluster]
+	pip install -e .
 	pip install -r ./requirements-dev.txt
 .PHONY: develop
 

--- a/sentry_redis_tools/clients.py
+++ b/sentry_redis_tools/clients.py
@@ -1,9 +1,5 @@
 from typing import NoReturn
-
-try:
-    from redis import RedisCluster
-except ImportError:
-    from rediscluster import RedisCluster
+from redis.cluster import RedisCluster
 
 try:
     from rb import Cluster as BlasterClient

--- a/sentry_redis_tools/failover_redis.py
+++ b/sentry_redis_tools/failover_redis.py
@@ -4,7 +4,7 @@ import random
 import time
 from typing import Any, Callable, Optional
 
-from sentry_redis_tools.clients import StrictRedis
+from redis.client import Pipeline, StrictRedis
 from redis.exceptions import (
     ConnectionError,
     ReadOnlyError,
@@ -131,7 +131,7 @@ class FailoverRedis(StrictRedis):  # type: ignore
 
     execute_command = _sentry_wrap_with_retry(lambda: StrictRedis.execute_command)
 
-    def pipeline(self, *args: Any, **kwargs: Any) -> Any:
+    def pipeline(self, *args: Any, **kwargs: Any) -> Pipeline:
         rv = StrictRedis.pipeline(self, *args, **kwargs)
         old_execute = rv.execute
         rv.execute = _sentry_wrap_with_retry(lambda: old_execute, client_self=self)

--- a/sentry_redis_tools/retrying_cluster.py
+++ b/sentry_redis_tools/retrying_cluster.py
@@ -1,12 +1,6 @@
 from typing import Any
-from sentry_redis_tools.clients import RedisCluster
-
-from redis.exceptions import BusyLoadingError, ConnectionError
-
-try:
-    from redis.exceptions import ClusterError
-except ImportError:
-    from rediscluster.exceptions import ClusterError
+from redis.cluster import RedisCluster
+from redis.exceptions import BusyLoadingError, ConnectionError, ClusterError
 
 __all__ = ["ClusterError", "RetryingRedisCluster"]
 
@@ -29,12 +23,6 @@ class RetryingRedisCluster(RedisCluster):  # type: ignore
             ClusterError,
             KeyError,  # see: https://github.com/Grokzen/redis-py-cluster/issues/287
         ):
-            # Codepath for redis-py-cluster
-            if hasattr(self, "connection_pool"):
-                self.connection_pool.nodes.reset()
-
-            # Codepath for redis.cluster
-            #
             # the code in the RedisCluster __init__ idiotically sets
             # self.nodes_manager = None
             # self.nodes_manager = NodesManager(...)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 from setuptools import find_packages, setup
 
-from typing import Sequence
-
-
 setup(
     name="sentry-redis-tools",
     version="0.2.0",
@@ -12,10 +9,7 @@ setup(
     url="https://github.com/getsentry/sentry-redis-tools",
     description="Common utilities related to how Sentry uses Redis",
     zip_safe=False,
-    install_requires=['redis>=3.0'],
-    extras_require={
-     "cluster": ["redis-py-cluster>=2.1.0"],
-    },
+    install_requires=['redis>=4.0'],
     packages=find_packages(exclude=("tests", "tests.*")),
     package_data={"sentry_redis_tools": ["py.typed"]},
     include_package_data=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,12 @@
 from typing import Union, Type
 
 import pytest
-import redis
 
 from sentry_redis_tools.clients import StrictRedis, BlasterClient, RedisCluster
 
 
 def initialize_redis_cluster(cls: Type[RedisCluster] = RedisCluster) -> RedisCluster:
-    if redis.VERSION >= (4,):
-        client = cls.from_url("redis://127.0.0.1:16379")
-    else:
-        client = cls(startup_nodes=[{"host": "127.0.0.1", "port": "16379"}])
-
+    client = cls.from_url("redis://127.0.0.1:16379")
     client.flushdb()
     return client
 


### PR DESCRIPTION
Removes `rediscluster` since we don't use it on Sentry anymore, and increased redis dependency to v4, since it is the oldest Redis version to support RedisCluster out of the box.