### PR TITLE
build: update redis docker image to v7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,7 @@
 version: '3'
 services:
   redis-cluster:
-    # Pinning to v6 until https://github.com/Grokzen/docker-redis-cluster/issues/155 is released
-    image: grokzen/redis-cluster:6.2.11
+    image: grokzen/redis-cluster:7.0.10
     ports:
       - '16379-16384:16379-16384'
     environment:


### PR DESCRIPTION
v7 was released a long time ago. We can update it now.

Note: This is used only for testing.