### PR TITLE
IA-12: re-initialize cluster details on TimeoutError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Install redis-cli
         run: sudo apt-get install redis-tools
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
       - run: make develop
       - run: make redis-cluster
       - run: pip install redis==${{ matrix.redis-py }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 ---
-version: "3"
+version: '3'
 services:
   redis-cluster:
-    image: grokzen/redis-cluster:6.2.11
+    image: grokzen/redis-cluster:7.0.10
     ports:
-      - "16379-16384:16379-16384"
+      - '16379-16384:16379-16384'
     environment:
-      IP: "0.0.0.0"
+      IP: '0.0.0.0'
       INITIAL_PORT: 16379
 
   single-redis:
     image: redis
     ports:
-      - "6379:6379"
+      - '6379:6379'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,15 @@
 ---
-version: '3'
+version: "3"
 services:
   redis-cluster:
-    image: grokzen/redis-cluster:7.0.10
+    image: grokzen/redis-cluster:6.2.11
     ports:
-      - '16379-16384:16379-16384'
+      - "16379-16384:16379-16384"
     environment:
-      IP: '0.0.0.0'
+      IP: "0.0.0.0"
       INITIAL_PORT: 16379
 
   single-redis:
     image: redis
     ports:
-      - '6379:6379'
+      - "6379:6379"

--- a/sentry_redis_tools/retrying_cluster.py
+++ b/sentry_redis_tools/retrying_cluster.py
@@ -1,6 +1,11 @@
 from typing import Any
 from redis.cluster import RedisCluster
-from redis.exceptions import BusyLoadingError, ConnectionError, ClusterError
+from redis.exceptions import (
+    BusyLoadingError,
+    ConnectionError,
+    ClusterError,
+    TimeoutError,
+)
 
 __all__ = ["ClusterError", "RetryingRedisCluster"]
 
@@ -21,6 +26,7 @@ class RetryingRedisCluster(RedisCluster):  # type: ignore
             ConnectionError,
             BusyLoadingError,
             ClusterError,
+            TimeoutError,
             KeyError,  # see: https://github.com/Grokzen/redis-py-cluster/issues/287
         ):
             # the code in the RedisCluster __init__ idiotically sets


### PR DESCRIPTION
### [IA-12](https://getsentry.atlassian.net/browse/IA-12)

During INC-867 we saw some sort of maintenance / failover even in our Redis-cluster, leading to some changes in redis hosts / ports. Some of our backpressure checks began to error with `TimeoutError` until the pods were restarted (causing the cluster nodes to be rediscovered).