### PR TITLE
chore: Revert removing rediscluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/setup-python@v5
 
       - run: make develop
-      - run: pip install redis==4.*
       - run: make lint
       - run: make format
       - run: git diff --quiet || (echo '::error ::lint produced file changes, run linter locally and try again' && exit 1)
@@ -28,7 +27,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        redis-py: [4.*]
+        redis-py: [3.*, 4.*]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 develop:
-	pip install -e .
+	pip install -e .[cluster]
 	pip install -r ./requirements-dev.txt
 .PHONY: develop
 

--- a/sentry_redis_tools/clients.py
+++ b/sentry_redis_tools/clients.py
@@ -1,5 +1,9 @@
 from typing import NoReturn
-from redis.cluster import RedisCluster
+
+try:
+    from redis import RedisCluster
+except ImportError:
+    from rediscluster import RedisCluster
 
 try:
     from rb import Cluster as BlasterClient

--- a/sentry_redis_tools/failover_redis.py
+++ b/sentry_redis_tools/failover_redis.py
@@ -4,7 +4,7 @@ import random
 import time
 from typing import Any, Callable, Optional
 
-from redis.client import Pipeline, StrictRedis
+from sentry_redis_tools.clients import StrictRedis
 from redis.exceptions import (
     ConnectionError,
     ReadOnlyError,
@@ -131,7 +131,7 @@ class FailoverRedis(StrictRedis):  # type: ignore
 
     execute_command = _sentry_wrap_with_retry(lambda: StrictRedis.execute_command)
 
-    def pipeline(self, *args: Any, **kwargs: Any) -> Pipeline:
+    def pipeline(self, *args: Any, **kwargs: Any) -> Any:
         rv = StrictRedis.pipeline(self, *args, **kwargs)
         old_execute = rv.execute
         rv.execute = _sentry_wrap_with_retry(lambda: old_execute, client_self=self)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ setup(
     url="https://github.com/getsentry/sentry-redis-tools",
     description="Common utilities related to how Sentry uses Redis",
     zip_safe=False,
-    install_requires=['redis>=4.0'],
+    install_requires=['redis>=3.0'],
+    extras_require={
+     "cluster": ["redis-py-cluster>=2.1.0"],
+    },
     packages=find_packages(exclude=("tests", "tests.*")),
     package_data={"sentry_redis_tools": ["py.typed"]},
     include_package_data=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def initialize_redis_cluster(cls: Type[RedisCluster] = RedisCluster) -> RedisClu
     if redis.VERSION >= (4,):
         client = cls.from_url("redis://127.0.0.1:16379")
     else:
-        client = cls(startup_nodes=[{"host": "127.0.0.1", "port": "16379"}])    
+        client = cls(startup_nodes=[{"host": "127.0.0.1", "port": "16379"}])
 
     client.flushdb()
     return client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,17 @@
 from typing import Union, Type
 
 import pytest
+import redis
 
 from sentry_redis_tools.clients import StrictRedis, BlasterClient, RedisCluster
 
 
 def initialize_redis_cluster(cls: Type[RedisCluster] = RedisCluster) -> RedisCluster:
-    client = cls.from_url("redis://127.0.0.1:16379")
+    if redis.VERSION >= (4,):
+        client = cls.from_url("redis://127.0.0.1:16379")
+    else:
+        client = cls(startup_nodes=[{"host": "127.0.0.1", "port": "16379"}])    
+
     client.flushdb()
     return client
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/88559
requires some fixes in sentry-redis-tools but running into dependency issues trying to bump the package version. 
```
ERROR: Cannot install -r requirements-dev-frozen.txt (line 167), -r requirements-dev-frozen.txt (line 169), -r requirements-dev-frozen.txt (line 193) and redis==3.4.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested redis==3.4.1
    rb 1.10.0 depends on redis!=3.4.0 and >=2.6
    redis-py-cluster 2.1.0 depends on redis<4.0.0 and >=3.0.0
    sentry-redis-tools 0.4.0 depends on redis>=4.0
```

reverting https://github.com/getsentry/sentry-redis-tools/pull/12/files per @untitaker's suggestion [here](https://github.com/getsentry/sentry/pull/88559#issuecomment-2772924029). I reverted all the changes in that commit since I wasn't sure what is pertinent to the `redis>=3.0` -> `redis>=4.0` change. Had to manually port the changes, since files had changed for me to be able to open an automatic revert PR.